### PR TITLE
Fix err when trying to fetch msgs from channel with no read permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+.token_cache

--- a/workers/deletion.py
+++ b/workers/deletion.py
@@ -100,21 +100,26 @@ class DeletionWorker(QThread):
             params = {"limit": 100}
             if before:
                 params["before"] = before
-                
+
             response = self.session.get(
                 f"{BASE_URL}/channels/{channel_id}/messages",
                 headers=self.headers,
                 params=params,
                 timeout=15
             )
+
             messages = response.json()
-            
+
+            if not isinstance(messages, list):
+                return
+
             for msg in messages:
                 if msg["author"]["id"] == self.user_id:
                     self.all_messages.append((msg["id"], channel_id, context))
-            
+
             if len(messages) < 100:
                 break
+
             before = messages[-1]["id"]
 
     def delete_message(self, message_id, channel_id):


### PR DESCRIPTION
Fix err when trying to fetch msgs from server channel with no read permissions

string indices must be integers not str